### PR TITLE
Allowing compilation on msys2

### DIFF
--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -52,6 +52,7 @@ jobs:
             qt6-webchannel:p
             qt6-websockets:p
             x264:p
+            cc:p
 
       - name: Configure and build RetroArch
         shell: msys2 {0}

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -67,8 +67,7 @@ jobs:
           echo "Collecting DLLs and binaries"
           mkdir -p dist
           cp retroarch.exe dist/
-          MSYS_LOWER=$(echo "${{ matrix.sys }}" | tr '[:upper:]' '[:lower:]')
-          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${MSYS_LOWER}/bin/" | xargs -I {} cp {} dist/
+          ldd retroarch.exe|grep $MINGW_PREFIX |awk '{print $3}'|xargs -I {} cp {} dist/
 
       - name: Archive build artifacts
         if: success()

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -72,7 +72,7 @@ jobs:
           echo "Collecting DLLs and binaries"
           mkdir -p dist
           cp retroarch.exe dist/
-          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${{ matrix.sys | lower }}/bin/" | xargs -I {} cp {} dist/
+          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${{ toLowerCase(matrix.sys) }}/bin/" | xargs -I {} cp {} dist/
 
       - name: Archive build artifacts
         if: success()

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -61,12 +61,6 @@ jobs:
           ./configure
           make -j$(nproc)
 
-      - name: Run tests (if any)
-        shell: msys2 {0}
-        run: |
-          echo "Running tests in ${{ matrix.sys }} environment"
-          make check
-
       - name: Collect DLLs and binaries
         shell: msys2 {0}
         run: |

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -1,0 +1,82 @@
+name: CI Windows (MSYS2)
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+permissions:
+  contents: read
+
+jobs:
+  msys2-build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        sys: [MINGW64, UCRT64]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: base-devel git
+          pacboy: >-
+            gettext:p
+            gobject-introspection:p
+            graphite2:p
+            p11-kit:p
+            qt6:p
+            qt6-3d:p
+            qt6-charts:p
+            qt6-datavis3d:p
+            qt6-imageformats:p
+            qt6-location:p
+            qt6-lottie:p
+            qt6-networkauth:p
+            qt6-quick3dphysics:p
+            qt6-quicktimeline:p
+            qt6-remoteobjects:p
+            qt6-scxml:p
+            qt6-sensors:p
+            qt6-serialbus:p
+            qt6-speech:p
+            qt6-tools:p
+            qt6-translations:p
+            qt6-virtualkeyboard:p
+            qt6-webchannel:p
+            qt6-websockets:p
+            x264:p
+
+      - name: Configure and build RetroArch
+        shell: msys2 {0}
+        run: |
+          echo "Building RetroArch in ${{ matrix.sys }} environment"
+          ./configure
+          make -j$(nproc)
+
+      - name: Run tests (if any)
+        shell: msys2 {0}
+        run: |
+          echo "Running tests in ${{ matrix.sys }} environment"
+          make check
+
+      - name: Collect DLLs and binaries
+        shell: msys2 {0}
+        run: |
+          echo "Collecting DLLs and binaries"
+          mkdir -p dist
+          cp retroarch.exe dist/
+          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${{ matrix.sys | lower }}/bin/" | xargs -I {} cp {} dist/
+
+      - name: Archive build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retroarch-${{ matrix.sys }}
+          path: dist/

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -72,7 +72,8 @@ jobs:
           echo "Collecting DLLs and binaries"
           mkdir -p dist
           cp retroarch.exe dist/
-          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${{ toLowerCase(matrix.sys) }}/bin/" | xargs -I {} cp {} dist/
+          MSYS_LOWER=$(echo "${{ matrix.sys }}" | tr '[:upper:]' '[:lower:]')
+          ldd retroarch.exe | grep "${{ matrix.sys }}" | awk '{print $3}' | grep -i "/${MSYS_LOWER}/bin/" | xargs -I {} cp {} dist/
 
       - name: Archive build artifacts
         if: success()

--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys: [MINGW64, UCRT64]
+        sys: [MINGW64, UCRT64,CLANG64]
     runs-on: windows-latest
     steps:
       - name: Checkout repository

--- a/Makefile.common
+++ b/Makefile.common
@@ -2648,4 +2648,26 @@ ifeq ($(HAVE_ODROIDGO2), 1)
          gfx/drivers/oga_gfx.o
 endif
 
+
+ifneq ($(findstring Win32,$(OS)),)
+# This block executes only if $(OS) contains "Win32"
+NT_VERSION := $(shell echo "#include <windows.h>" > temp.c; \
+               echo "#ifdef _WIN32_WINNT" >> temp.c; \
+               echo "#define GET_MACRO_VALUE(x) #x" >> temp.c; \
+               echo "#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)" >> temp.c; \
+               echo "#pragma message (\"_WIN32_WINNT=\" EXPAND_MACRO_VALUE(_WIN32_WINNT))" >> temp.c; \
+               echo "#endif" >> temp.c; \
+               $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; \
+               rm -f temp.c temp.o)
+
+# Check if NT_VERSION is greater than 0x602
+ifneq ($(NT_VERSION),)
+ifeq ($(shell [ $$(( $(NT_VERSION) )) -gt $$(( 0x602 )) ] && echo true), true)
+LIBS += -lxaudio2_9
+endif
+else
+$(warning Windows NT version macro (_WIN32_WINNT) is not defined.)
+endif
+endif
+
 ##################################

--- a/Makefile.common
+++ b/Makefile.common
@@ -2649,20 +2649,19 @@ ifeq ($(HAVE_ODROIDGO2), 1)
 endif
 
 ifneq ($(findstring Win32,$(OS)),)
-ifneq ($(shell sh -c 'command -v sh'),)  # Check if we have a Unix shell
-# This block executes only if $(OS) contains "Win32" and we're in a Unix shell
-NT_VERSION := $(shell echo "#include <windows.h>" > temp.c && \
-               echo "#ifdef _WIN32_WINNT" >> temp.c && \
-               echo "#define GET_MACRO_VALUE(x) #x" >> temp.c && \
-               echo "#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)" >> temp.c && \
-               echo "#pragma message (\"_WIN32_WINNT=\" EXPAND_MACRO_VALUE(_WIN32_WINNT))" >> temp.c && \
-               echo "#endif" >> temp.c && \
-               $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p' && \
-               rm -f temp.c temp.o)
+ifneq ($(shell sh -c 'command -v sh'),)
+NT_VERSION := $(shell \
+  echo '#include <windows.h>' > temp.c; \
+  echo '#ifdef _WIN32_WINNT' >> temp.c; \
+  echo '#define GET_MACRO_VALUE(x) #x' >> temp.c; \
+  echo '#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)' >> temp.c; \
+  echo '#pragma message("_WIN32_WINNT=" EXPAND_MACRO_VALUE(_WIN32_WINNT))' >> temp.c; \
+  echo '#endif' >> temp.c; \
+  $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; \
+  rm -f temp.c temp.o)
 
-# Check if NT_VERSION is greater than 0x602
 ifneq ($(NT_VERSION),)
-ifeq ($(shell [ $$(( $(NT_VERSION) )) -gt $$(( 0x602 )) ] && echo true), true)
+ifeq ($(shell [ $$(( $(NT_VERSION) )) -gt $$(( 0x602 )) ] && echo true),true)
 LIBS += -lxaudio2_9
 endif
 else
@@ -2670,4 +2669,6 @@ $(warning Windows NT version macro (_WIN32_WINNT) is not defined.)
 endif
 endif
 endif
+
+
 ##################################

--- a/Makefile.common
+++ b/Makefile.common
@@ -2648,16 +2648,16 @@ ifeq ($(HAVE_ODROIDGO2), 1)
          gfx/drivers/oga_gfx.o
 endif
 
-
 ifneq ($(findstring Win32,$(OS)),)
-# This block executes only if $(OS) contains "Win32"
-NT_VERSION := $(shell echo "#include <windows.h>" > temp.c; \
-               echo "#ifdef _WIN32_WINNT" >> temp.c; \
-               echo "#define GET_MACRO_VALUE(x) #x" >> temp.c; \
-               echo "#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)" >> temp.c; \
-               echo "#pragma message (\"_WIN32_WINNT=\" EXPAND_MACRO_VALUE(_WIN32_WINNT))" >> temp.c; \
-               echo "#endif" >> temp.c; \
-               $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; \
+ifneq ($(shell sh -c 'command -v sh'),)  # Check if we have a Unix shell
+# This block executes only if $(OS) contains "Win32" and we're in a Unix shell
+NT_VERSION := $(shell echo "#include <windows.h>" > temp.c && \
+               echo "#ifdef _WIN32_WINNT" >> temp.c && \
+               echo "#define GET_MACRO_VALUE(x) #x" >> temp.c && \
+               echo "#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)" >> temp.c && \
+               echo "#pragma message (\"_WIN32_WINNT=\" EXPAND_MACRO_VALUE(_WIN32_WINNT))" >> temp.c && \
+               echo "#endif" >> temp.c && \
+               $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p' && \
                rm -f temp.c temp.o)
 
 # Check if NT_VERSION is greater than 0x602
@@ -2669,5 +2669,5 @@ else
 $(warning Windows NT version macro (_WIN32_WINNT) is not defined.)
 endif
 endif
-
+endif
 ##################################

--- a/Makefile.common
+++ b/Makefile.common
@@ -2648,9 +2648,22 @@ ifeq ($(HAVE_ODROIDGO2), 1)
          gfx/drivers/oga_gfx.o
 endif
 
-ifneq ($(findstring Win32,$(OS)),)
-ifneq ($(shell sh -c 'command -v sh'),)
-NT_VERSION := $(shell echo '#include <windows.h>' > temp.c; echo '#ifdef _WIN32_WINNT' >> temp.c; echo '#define GET_MACRO_VALUE(x) #x' >> temp.c; echo '#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)' >> temp.c; echo '#pragma message("_WIN32_WINNT=" EXPAND_MACRO_VALUE(_WIN32_WINNT))' >> temp.c; echo '#endif' >> temp.c; $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; rm -f temp.c temp.o)
+# Detect the operating system
+UNAME := $(shell uname -s)
+
+# Check if the system is MSYS2 (MINGW64 or MINGW32)
+ifneq ($(findstring MINGW,$(UNAME)),)
+$(info Detected MSYS2 environment)
+
+NT_VERSION := $(shell \
+  echo '#include <windows.h>' > temp.c; \
+  echo '#ifdef _WIN32_WINNT' >> temp.c; \
+  echo '#define GET_MACRO_VALUE(x) #x' >> temp.c; \
+  echo '#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)' >> temp.c; \
+  echo '#pragma message("_WIN32_WINNT=" EXPAND_MACRO_VALUE(_WIN32_WINNT))' >> temp.c; \
+  echo '#endif' >> temp.c; \
+  $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; \
+  rm -f temp.c temp.o)
 
 ifneq ($(NT_VERSION),)
 ifeq ($(shell [ $$(( $(NT_VERSION) )) -gt $$(( 0x602 )) ] && echo true),true)
@@ -2659,7 +2672,8 @@ endif
 else
 $(warning Windows NT version macro (_WIN32_WINNT) is not defined.)
 endif
-endif
+
+
 endif
 
 ##################################

--- a/Makefile.common
+++ b/Makefile.common
@@ -2650,15 +2650,7 @@ endif
 
 ifneq ($(findstring Win32,$(OS)),)
 ifneq ($(shell sh -c 'command -v sh'),)
-NT_VERSION := $(shell \
-  echo '#include <windows.h>' > temp.c; \
-  echo '#ifdef _WIN32_WINNT' >> temp.c; \
-  echo '#define GET_MACRO_VALUE(x) #x' >> temp.c; \
-  echo '#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)' >> temp.c; \
-  echo '#pragma message("_WIN32_WINNT=" EXPAND_MACRO_VALUE(_WIN32_WINNT))' >> temp.c; \
-  echo '#endif' >> temp.c; \
-  $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; \
-  rm -f temp.c temp.o)
+NT_VERSION := $(shell echo '#include <windows.h>' > temp.c; echo '#ifdef _WIN32_WINNT' >> temp.c; echo '#define GET_MACRO_VALUE(x) #x' >> temp.c; echo '#define EXPAND_MACRO_VALUE(x) GET_MACRO_VALUE(x)' >> temp.c; echo '#pragma message("_WIN32_WINNT=" EXPAND_MACRO_VALUE(_WIN32_WINNT))' >> temp.c; echo '#endif' >> temp.c; $(CC) -c temp.c 2>&1 | sed -n 's/^.*_WIN32_WINNT=\(0x[0-9A-Fa-f]\+\).*/\1/p'; rm -f temp.c temp.o)
 
 ifneq ($(NT_VERSION),)
 ifeq ($(shell [ $$(( $(NT_VERSION) )) -gt $$(( 0x602 )) ] && echo true),true)
@@ -2669,6 +2661,5 @@ $(warning Windows NT version macro (_WIN32_WINNT) is not defined.)
 endif
 endif
 endif
-
 
 ##################################

--- a/audio/common/mmdevice_common_inline.h
+++ b/audio/common/mmdevice_common_inline.h
@@ -20,10 +20,6 @@
 
 /* Fix for MSYS2 increasing _WIN32_WINNT to 0x0603*/
 #if defined(__MINGW32__) || defined(__MINGW64__)
-#ifdef _WIN32_WINNT
-#undef _WIN32_WINNT
-#endif
-#define _WIN32_WINNT 0x0600
 #define WIN32_LEAN_AND_MEAN
 #else
 typedef enum EDataFlow EDataFlow;


### PR DESCRIPTION
## Description
Before there was no clear way of running msys2, and even if there was, there is no guarantee of it working, well I fixed it, and added a CI, so that we can always know if it works. Furthermore I added 2 targets more: UCRT64 and CLANG64, yes, compilation with clang64 means we can also compile with clang for windows on arm :D, plus clang has better error messages overall, anyway.

## Related Issues

#17367

## Reviewers
Anyone, it's my first PR here.